### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,10 +6,10 @@ GP22	KEYWORD1
 
 begin	KEYWORD2
 measure	KEYWORD2
-readStatus KEYWORD2
+readStatus	KEYWORD2
 readResult	KEYWORD2
 testComms	KEYWORD2
 measConv	KEYWORD2
-setExpectedHits KEYWORD2
-getExpectedHits KEYWORD2
+setExpectedHits	KEYWORD2
+getExpectedHits	KEYWORD2
 updateConfig	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords